### PR TITLE
Change GPT-3 -> GPT-4 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This Readme is just the high level overview of the space; you should see the mos
 
 - `IMAGE_GEN.md` - the most developed file, with the heaviest emphasis notes on Stable Diffusion, and some on midjourney and dalle.
 	- `IMAGE_PROMPTS.md` - a small [swipe file](https://www.swyx.io/swipe-files-strategy) of good image prompts
-- `TEXT.md` - text generation, mostly with GPT3
+- `TEXT.md` - text generation, mostly with GPT-4
 	- `TEXT_CHAT.md` - information on ChatGPT and competitors, as well as derivative products
-	- `TEXT_SEARCH.md` - information on GPT3 enabled semantic search and other info
+	- `TEXT_SEARCH.md` - information on GPT-4 enabled semantic search and other info
 	- `TEXT_PROMPTS.md` - a small [swipe file](https://www.swyx.io/swipe-files-strategy) of good GPT3 prompts
 - `INFRA.md` - raw notes on AI Infrastructure, Hardware and Scaling
 - `AUDIO.md` - tracking audio/music/voice transcription + generation


### PR DESCRIPTION
The current README mentions that TEXT.md centers around GPT-3 and hasn't been updated to reflect the release of GPT-4. I have updated 2 mentions of GPT-3 with this. Please let me know if you want me to change anything else. Thanks!